### PR TITLE
C6: update site for cohort 6 launch

### DIFF
--- a/src/components/ctas/CtaSix.astro
+++ b/src/components/ctas/CtaSix.astro
@@ -16,11 +16,11 @@ import RoundedGrid from '../assets/RoundedGrid.astro';
           <p class="max-w-xl mx-auto mt-4 text-vulcan-300">
             Learn from the best in the industry to scale your DevRel career!
           </p>
-          <span class="text-vulcan-400 text-sm mt-2">Application starts February, 10 until February, 23 2025.</span>
+          <span class="text-vulcan-400 text-sm mt-2">Applications open April 27, 2026.</span>
         </div>
         <div class="flex justify-center mt-8">
           <a
-            href="https://forms.gle/d6DNATNStTYkqVM89"
+            href="https://forms.gle/s7tZGcCLsEYCey9X7"
             class="flex items-center justify-center w-auto h-10 px-4 py-2 text-sm font-semibold text-white transition-all rounded-lg hover:to-indigo-600 bg-gradient-to-b from-indigo-300 via-indigo-400 to-indigo-500"
             >Apply Now</a
           >

--- a/src/components/features/Curriculum.astro
+++ b/src/components/features/Curriculum.astro
@@ -1,86 +1,141 @@
 ---
 import Verticalgrid from '../assets/Verticalgrid.astro';
 
-const curriculum = [
+const cohort6 = [
   {
-    weeks: [
-      {
-        title: 'Week 1: Developer Advocacy Foundations & AI Tools',
-        content: [
-          'Role and impact of Developer Advocates in 2025',
-          'Using AI tools for developer advocacy',
-          'Building developer-first mindset',
-        ],
-      },
-      {
-        title: 'Week 2: Technical Content Strategy',
-        content: [
-          'Creating effective technical documentation',
-          'Documentation-as-code practices',
-          'Content distribution and SEO for technical content',
-        ],
-      },
-      {
-        title: 'Week 3: Modern Community Building',
-        content: [
-          'Building communities in a remote-first world',
-          'Community engagement tactics',
-          'Managing developer feedback',
-        ],
-      },
-      {
-        title: 'Week 4: Core Technical Skills',
-        content: ['Modern web development overview', 'Working with APIs and SDKs', 'Developer tools and platforms'],
-      },
-      {
-        title: 'Week 5: Video & Interactive Content',
-        content: [
-          'Creating developer-focused video content',
-          'Interactive documentation techniques',
-          'Presentation skills for technical audiences',
-        ],
-      },
-      {
-        title: 'Week 6: Developer Event Strategy',
-        content: [
-          'Planning virtual and hybrid events',
-          'Event formats and engagement strategies',
-          'Measuring event success',
-        ],
-      },
-      {
-        title: 'Week 7: Developer Experience',
-        content: [
-          'DX principles and best practices',
-          'User research for developers',
-          'Feedback loops and implementation',
-        ],
-      },
-      {
-        title: 'Week 8: Developer Marketing Essentials',
-        content: [
-          'Developer marketing fundamentals',
-          'Content strategy for developers',
-          'DevRel and marketing alignment',
-        ],
-      },
-      {
-        title: 'Week 9: Metrics That Matter',
-        content: ['Key DevRel metrics', 'Data analysis for advocacy', 'Impact reporting'],
-      },
-      {
-        title: 'Week 10: Strategic DevRel',
-        content: ['Cross-functional collaboration', 'Building developer programs', 'Global developer relations'],
-      },
-      {
-        title: 'Week 11: Future Technologies',
-        content: ['AI/ML developer tools', 'Web3 and blockchain basics', 'Emerging platforms'],
-      },
-      {
-        title: 'Week 12: Final Presentations',
-        content: ['Advocacy strategy presentation', 'Program implementation plan', 'Peer feedback session'],
-      },
+    title: 'Week 1: DevRel 101',
+    content: [
+      'Role and responsibilities of a Developer Advocate',
+      'Building a developer-first mindset',
+      'Getting started in the DevRel ecosystem',
     ],
+  },
+  {
+    title: 'Week 2: DevRel in the Age of AI',
+    content: [
+      'How AI is reshaping developer relations',
+      'Using AI tools to scale your advocacy work',
+      'Emerging opportunities at the intersection of AI and DevRel',
+    ],
+  },
+  {
+    title: 'Week 3: Content Production for DevRels',
+    content: [
+      'Writing technical content that resonates with developers',
+      'Video, livestreams, and interactive content formats',
+      'Building and distributing a content strategy',
+    ],
+  },
+  {
+    title: 'Week 4: Events',
+    content: [
+      'Planning and running developer events',
+      'Engaging communities at conferences and meetups',
+      'Measuring event impact and follow-up strategies',
+    ],
+  },
+  {
+    title: 'Week 5: Hackathon & Presentations',
+    content: [
+      'Hands-on hackathon challenge',
+      'Building and pitching a DevRel project',
+      'Peer feedback and iteration',
+    ],
+  },
+  {
+    title: 'Week 6: Product & GTM',
+    content: [
+      "DevRel's role in go-to-market strategy",
+      'Collaborating with product and marketing teams',
+      'Influencing roadmap through developer feedback',
+    ],
+  },
+  {
+    title: 'Week 7: Graduation',
+    content: [
+      'Final presentations and showcase',
+      'Celebrating cohort achievements',
+      'Next steps and career guidance',
+    ],
+  },
+];
+
+const previousCurriculum = [
+  {
+    title: 'Week 1: Developer Advocacy Foundations & AI Tools',
+    content: [
+      'Role and impact of Developer Advocates in 2025',
+      'Using AI tools for developer advocacy',
+      'Building developer-first mindset',
+    ],
+  },
+  {
+    title: 'Week 2: Technical Content Strategy',
+    content: [
+      'Creating effective technical documentation',
+      'Documentation-as-code practices',
+      'Content distribution and SEO for technical content',
+    ],
+  },
+  {
+    title: 'Week 3: Modern Community Building',
+    content: [
+      'Building communities in a remote-first world',
+      'Community engagement tactics',
+      'Managing developer feedback',
+    ],
+  },
+  {
+    title: 'Week 4: Core Technical Skills',
+    content: ['Modern web development overview', 'Working with APIs and SDKs', 'Developer tools and platforms'],
+  },
+  {
+    title: 'Week 5: Video & Interactive Content',
+    content: [
+      'Creating developer-focused video content',
+      'Interactive documentation techniques',
+      'Presentation skills for technical audiences',
+    ],
+  },
+  {
+    title: 'Week 6: Developer Event Strategy',
+    content: [
+      'Planning virtual and hybrid events',
+      'Event formats and engagement strategies',
+      'Measuring event success',
+    ],
+  },
+  {
+    title: 'Week 7: Developer Experience',
+    content: [
+      'DX principles and best practices',
+      'User research for developers',
+      'Feedback loops and implementation',
+    ],
+  },
+  {
+    title: 'Week 8: Developer Marketing Essentials',
+    content: [
+      'Developer marketing fundamentals',
+      'Content strategy for developers',
+      'DevRel and marketing alignment',
+    ],
+  },
+  {
+    title: 'Week 9: Metrics That Matter',
+    content: ['Key DevRel metrics', 'Data analysis for advocacy', 'Impact reporting'],
+  },
+  {
+    title: 'Week 10: Strategic DevRel',
+    content: ['Cross-functional collaboration', 'Building developer programs', 'Global developer relations'],
+  },
+  {
+    title: 'Week 11: Future Technologies',
+    content: ['AI/ML developer tools', 'Web3 and blockchain basics', 'Emerging platforms'],
+  },
+  {
+    title: 'Week 12: Final Presentations',
+    content: ['Advocacy strategy presentation', 'Program implementation plan', 'Peer feedback session'],
   },
 ];
 ---
@@ -94,46 +149,100 @@ const curriculum = [
           Our Curriculum
         </p>
         <p class="mt-8 text-lg font-normal tracking-tight text-white">
-          We're excited to go on this journey with you and we've mapped out this curriculum to direct our paths for the
-          next 12 weeks. For this cohort we'll cover this curriculum, go over their practical applications, and
-          occassionally bring experts in these areas to teach and share their knowledge and experiences.
+          We're excited to go on this journey with you. Over 7 weeks we'll cover the core pillars of Developer
+          Relations, hear from industry experts, and work through real-world scenarios to prepare you for a career in
+          DevRel.
         </p>
       </div>
     </div>
 
     <ul class="grid grid-cols-1 gap-6 mt-12 list-none sm:grid-cols-2 lg:grid-cols-3 lg:gap-12 lg:mt-24">
       {
-        curriculum.map((curriculumWeek) =>
-          curriculumWeek.weeks.map((weekData) => (
-            <li class="gap-3">
-              <h3 class="text-xl font-bold text-white">{weekData.title}</h3>
-              <ul>
-                {weekData.content.map((contentItem) => (
-                  <li>
-                    <div class="relative flex items-center py-2">
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        class="w-4 h-4 text-indigo-400 icon icon-tabler icon-tabler-circle-check"
-                        viewBox="0 0 24 24"
-                        stroke-width="2"
-                        stroke="currentColor"
-                        fill="none"
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                      >
-                        <path stroke="none" d="M0 0h24v24H0z" fill="none" />
-                        <path d="M12 12m-9 0a9 9 0 1 0 18 0a9 9 0 1 0 -18 0" />
-                        <path d="M9 12l2 2l4 -4" />
-                      </svg>
-                      <p class="ml-2 text-sm leading-6 text-vulcan-300">{contentItem}</p>
-                    </div>
-                  </li>
-                ))}
-              </ul>
-            </li>
-          )),
-        )
+        cohort6.map((weekData) => (
+          <li class="gap-3">
+            <h3 class="text-xl font-bold text-white">{weekData.title}</h3>
+            <ul>
+              {weekData.content.map((contentItem) => (
+                <li>
+                  <div class="relative flex items-center py-2">
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      class="w-4 h-4 text-indigo-400 icon icon-tabler icon-tabler-circle-check"
+                      viewBox="0 0 24 24"
+                      stroke-width="2"
+                      stroke="currentColor"
+                      fill="none"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    >
+                      <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+                      <path d="M12 12m-9 0a9 9 0 1 0 18 0a9 9 0 1 0 -18 0" />
+                      <path d="M9 12l2 2l4 -4" />
+                    </svg>
+                    <p class="ml-2 text-sm leading-6 text-vulcan-300">{contentItem}</p>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </li>
+        ))
       }
     </ul>
+
+    <!-- Previous curriculum collapsible -->
+    <div class="mt-24">
+      <details class="group">
+        <summary
+          class="flex items-center justify-between cursor-pointer list-none text-white/50 hover:text-white/80 transition-colors text-sm font-medium"
+        >
+          <span>Previous curriculum</span>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            class="w-4 h-4 transition-transform group-open:rotate-180"
+            viewBox="0 0 24 24"
+            stroke-width="2"
+            stroke="currentColor"
+            fill="none"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+            <path d="M6 9l6 6l6 -6" />
+          </svg>
+        </summary>
+        <ul class="grid grid-cols-1 gap-6 mt-12 list-none sm:grid-cols-2 lg:grid-cols-3 lg:gap-12">
+          {
+            previousCurriculum.map((weekData) => (
+              <li class="gap-3">
+                <h3 class="text-xl font-bold text-white/60">{weekData.title}</h3>
+                <ul>
+                  {weekData.content.map((contentItem) => (
+                    <li>
+                      <div class="relative flex items-center py-2">
+                        <svg
+                          xmlns="http://www.w3.org/2000/svg"
+                          class="w-4 h-4 text-indigo-400/50"
+                          viewBox="0 0 24 24"
+                          stroke-width="2"
+                          stroke="currentColor"
+                          fill="none"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                        >
+                          <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+                          <path d="M12 12m-9 0a9 9 0 1 0 18 0a9 9 0 1 0 -18 0" />
+                          <path d="M9 12l2 2l4 -4" />
+                        </svg>
+                        <p class="ml-2 text-sm leading-6 text-vulcan-300/50">{contentItem}</p>
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              </li>
+            ))
+          }
+        </ul>
+      </details>
+    </div>
   </div>
 </section>

--- a/src/components/forms/Contact.astro
+++ b/src/components/forms/Contact.astro
@@ -8,7 +8,7 @@
           <div>
             <h2 class="text-3xl font-normal tracking-tight text-white">Let's get started!</h2>
             <p class="mt-2 text-base text-vulcan-300">
-              Complete the details below to apply for the 3rd cohort of the DXMentorship program. Be as detailed as you
+              Complete the details below to apply for the 6th cohort of the DXMentorship program. Be as detailed as you
               can as we'll rely on your responses to make our selection.
             </p>
           </div>

--- a/src/components/global/Navigation.astro
+++ b/src/components/global/Navigation.astro
@@ -64,7 +64,7 @@
         >
 
         <a
-          href="https://forms.gle/SULV71vPdB2SgpPp9"
+          href="https://forms.gle/s7tZGcCLsEYCey9X7"
           class="rounded-lg px-4 py-2 text-sm h-8 transition-all flex items-center justify-center text-white bg-gradient-to-b from-white/[.105] to-white/[.15] hover:to-white/[.25] h-10 ring-1 ring-inset ring-white/20"
         >
           Apply Now!

--- a/src/components/heros/HeroTwo.astro
+++ b/src/components/heros/HeroTwo.astro
@@ -15,11 +15,11 @@ import Blurgradientleft from '../assets/Blurgradientleft.astro';
         <div
           class="inline-flex items-center rounded-full bg-white/5 backdrop-blur-xl border border-white/10 px-4 py-2 text-sm text-white/90"
         >
-          ✦ Cohort 5 is open!
+          ✦ Cohort 6 — Applications open April 27, 2026!
         </div>
         <p class="mt-10 text-4xl font-normal tracking-tighter text-white sm:text-5xl">
           Developer Relations Mentorship Program
-          <span class="lg:block">Kickstart Your DevRel Career in 90 Days</span>
+          <span class="lg:block">Kickstart Your DevRel Career in 7 Weeks</span>
         </p>
         <p class="max-w-2xl mx-auto mt-4 text-vulcan-300">
           Gain the skills, confidence, and industry connections you need to excel as a Developer Advocate. Our program
@@ -29,7 +29,7 @@ import Blurgradientleft from '../assets/Blurgradientleft.astro';
 
         <div class="flex flex-col justify-center max-w-xl gap-2 mx-auto mt-12 sm:flex-row">
           <a
-            href="https://forms.gle/SULV71vPdB2SgpPp9"
+            href="https://forms.gle/s7tZGcCLsEYCey9X7"
             class="flex items-center justify-center h-10 px-4 py-2 text-sm font-semibold text-white transition-all rounded-lg hover:to-indigo-600 bg-gradient-to-b from-indigo-300 via-indigo-400 to-indigo-500"
             >Apply</a
           >

--- a/src/pages/apply/index.astro
+++ b/src/pages/apply/index.astro
@@ -12,7 +12,7 @@ import Contact from '../../components/forms/Contact.astro';
     url: 'https://www.dxmentorship.com',
     title: 'Apply to the DX Mentorship Program',
     description:
-      'We are now accepting applications for the 3rd cohort of the DX Mentorship Program. Apply now to be a part of this 12-week program designed to charge you into the next phase of your DevRel career.',
+      'We are now accepting applications for the 6th cohort of the DX Mentorship Program. Apply now to be a part of this 7-week program designed to charge you into the next phase of your DevRel career.',
     images: [
       {
         url: 'https://github.com/Dxmentorship/dxmentorship/assets/66284362/52bb363f-dc4b-451a-9d22-160e6fddb7b5',

--- a/src/pages/curriculum/index.astro
+++ b/src/pages/curriculum/index.astro
@@ -7,13 +7,13 @@ import Curriculum from '../../components/features/Curriculum.astro';
 
 <AstroSeo
   title="Curriculum | DXMentorship"
-  description="DXMentorship is a 12-week mentorship program for developers who want to start a career in developer advocacy."
+  description="DXMentorship is a 7-week mentorship program for developers who want to start a career in developer advocacy."
   canonical="https://www.dxmentorship.com"
   openGraph={{
     url: 'https://www.dxmentorship.com',
     title: 'Community | DXMentorship',
     description:
-      'DXMentorship is a 12-week mentorship program for developers who want to start a career in developer advocacy.',
+      'DXMentorship is a 7-week mentorship program for developers who want to start a career in developer advocacy.',
     images: [
       {
         url: '/opengraph/curriculum-og.png',

--- a/src/pages/mentees/index.astro
+++ b/src/pages/mentees/index.astro
@@ -79,7 +79,7 @@ import MenteeCard from '../../components/mentees/MenteeCard.astro';
                 Join our next cohort and learn from industry experts to accelerate your DevRel career!
               </p>
               <a
-                href="https://forms.gle/SULV71vPdB2SgpPp9"
+                href="https://forms.gle/s7tZGcCLsEYCey9X7"
                 class="inline-flex items-center justify-center h-12 px-8 py-3 text-base font-semibold
 text-white transition-all rounded-lg hover:to-indigo-600 bg-gradient-to-b from-indigo-300 via-indigo-400
 to-indigo-500 shadow-lg shadow-indigo-500/50 hover:shadow-indigo-500/70"


### PR DESCRIPTION
- Bump cohort 5 → 6 across hero, form, apply page, and OG metadata
- Update program duration from 90 days / 12 weeks → 7 weeks
- Add cohort 6 curriculum; move previous curriculum into collapsible
- Set application open date to April 27, 2026
- Update all Google Form links to new cohort 6 application URL